### PR TITLE
控制台美化：解决没有使用轮播图的页面，控制台报错。

### DIFF
--- a/lib/swiper_init.js
+++ b/lib/swiper_init.js
@@ -16,9 +16,11 @@ var swiper = new Swiper('.blog-slider', {
 });
 
 var comtainer = document.getElementById('swiper_container');
-comtainer.onmouseenter = function() {
-  swiper.autoplay.stop();
-};
-comtainer.onmouseleave = function() {
-  swiper.autoplay.start();
-}
+  if (comtainer !== null) {
+    comtainer.onmouseenter = function() {
+      swiper.autoplay.stop();
+    };
+    comtainer.onmouseleave = function() {
+      swiper.autoplay.start();
+      }
+  } else {}


### PR DESCRIPTION
控制台美化：解决没有使用轮播图的页面，控制台报错。
`Uncaught TypeError: Cannot set property 'onmouseenter' of null`